### PR TITLE
Don't check the margin to group comments

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -446,7 +446,7 @@ let find_cmts ?(filter = Fn.const true) t pos loc =
       update_cmts t pos ~f:(Map.set ~key:loc ~data:not_picked) ;
       picked )
 
-let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =
+let break_comment_group source {Cmt.loc= a; _} {Cmt.loc= b; _} =
   let vertical_align =
     Location.line_difference a b = 1 && Location.compare_start_col a b = 0
   in
@@ -456,9 +456,7 @@ let break_comment_group source margin {Cmt.loc= a; _} {Cmt.loc= b; _} =
          (Source.tokens_between source a.loc_end b.loc_start
               ~filter:(function _ -> true) )
   in
-  not
-    ( (Location.is_single_line a margin && Location.is_single_line b margin)
-    && (vertical_align || horizontal_align) )
+  not (vertical_align || horizontal_align)
 
 let is_only_whitespaces s = String.for_all s ~f:Char.is_whitespace
 
@@ -616,10 +614,7 @@ let fmt_cmt (conf : Conf.t) cmt ~fmt_code (pos : Cmt.pos) =
 
 let fmt_cmts_aux t (conf : Conf.t) cmts ~fmt_code pos =
   let open Fmt in
-  let groups =
-    List.group cmts
-      ~break:(break_comment_group t.source conf.fmt_opts.margin.v)
-  in
+  let groups = List.group cmts ~break:(break_comment_group t.source) in
   vbox 0 ~name:"cmts"
     (list_pn groups (fun ~prev:_ group ~next ->
          ( match group with

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -165,6 +165,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to asterisk_prefixed_cmts.ml.stdout
+   (with-stderr-to asterisk_prefixed_cmts.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/asterisk_prefixed_cmts.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/asterisk_prefixed_cmts.ml.ref asterisk_prefixed_cmts.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/asterisk_prefixed_cmts.ml.err asterisk_prefixed_cmts.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to attribute_and_expression.ml.stdout
    (with-stderr-to attribute_and_expression.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/attribute_and_expression.ml})))))

--- a/test/passing/tests/asterisk_prefixed_cmts.ml
+++ b/test/passing/tests/asterisk_prefixed_cmts.ml
@@ -1,0 +1,16 @@
+let _ =
+  (* It is very confusing - same expression has two different types in two contexts:*)
+  (* 1. if passed as parameter it's RETURN_TYPE* since we are passing it as rvalue *)
+  (* 2. for return expression it's RETURN_TYPE since backend allows to treat it as lvalue*)
+  (*    of RETURN_TYPE *)
+  (* Implications: *)
+  (* Fields: field_deref_trans relies on it - if exp has RETURN_TYPE then *)
+  (*         it means that it's not lvalue in clang's AST (it'd be reference otherwise) *)
+  (* Methods: method_deref_trans actually wants a pointer to the object, which is*)
+  (*          equivalent of value of ret_param. Since ret_exp has type RETURN_TYPE,*)
+  (*          we optionally add pointer there to avoid backend confusion. *)
+  (*          It works either way *)
+  (* Passing by value: may cause problems - there needs to be extra Sil.Load, but*)
+  (*                   doing so would create problems with methods. Passing structs by*)
+  (*                   value doesn't work good anyway. This may need to be revisited later*)
+  let x = y in z

--- a/test/passing/tests/asterisk_prefixed_cmts.ml.err
+++ b/test/passing/tests/asterisk_prefixed_cmts.ml.err
@@ -1,0 +1,9 @@
+Warning: tests/asterisk_prefixed_cmts.ml:1 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:2 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:3 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:7 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:8 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:9 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:12 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:13 exceeds the margin
+Warning: tests/asterisk_prefixed_cmts.ml:14 exceeds the margin

--- a/test/passing/tests/asterisk_prefixed_cmts.ml.ref
+++ b/test/passing/tests/asterisk_prefixed_cmts.ml.ref
@@ -1,0 +1,17 @@
+let _ =
+  (* It is very confusing - same expression has two different types in two contexts:*)
+  (* 1. if passed as parameter it's RETURN_TYPE* since we are passing it as rvalue *)
+  (* 2. for return expression it's RETURN_TYPE since backend allows to treat it as lvalue*)
+  (*    of RETURN_TYPE *)
+  (* Implications: *)
+  (* Fields: field_deref_trans relies on it - if exp has RETURN_TYPE then *)
+  (*         it means that it's not lvalue in clang's AST (it'd be reference otherwise) *)
+  (* Methods: method_deref_trans actually wants a pointer to the object, which is*)
+  (*          equivalent of value of ret_param. Since ret_exp has type RETURN_TYPE,*)
+  (*          we optionally add pointer there to avoid backend confusion. *)
+  (*          It works either way *)
+  (* Passing by value: may cause problems - there needs to be extra Sil.Load, but*)
+  (*                   doing so would create problems with methods. Passing structs by*)
+  (*                   value doesn't work good anyway. This may need to be revisited later*)
+  let x = y in
+  z

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -10089,9 +10089,10 @@ let _ =
 (*$*)
 
 (*$
-  [%string {| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  zzzzzzzzzzzzzzzzzzzzzzzzzzzz
-      |}]
+  [%string
+    {| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+zzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    |}]
 *)
 (*$*)
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -1441,20 +1441,20 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
 ;;
 
 (*
-   type (_,_) ty_assoc =
-   | Anil : (unit,'e) ty_assoc
-   | Acons : string * ('a,'e) ty * ('b,'e) ty_assoc -> ('a -> 'b, 'e) ty_assoc
+type (_,_) ty_assoc =
+  | Anil : (unit,'e) ty_assoc
+  | Acons : string * ('a,'e) ty * ('b,'e) ty_assoc -> ('a -> 'b, 'e) ty_assoc
 
-   and (_,_) ty_pvar =
-   | Pnil : ('a,'e) ty_pvar
-   | Pconst : 't * ('b,'e) ty_pvar -> ('t -> 'b, 'e) ty_pvar
-   | Parg : 't * ('a,'e) ty * ('b,'e) ty_pvar -> ('t * 'a -> 'b, 'e) ty_pvar
+and (_,_) ty_pvar =
+  | Pnil : ('a,'e) ty_pvar
+  | Pconst : 't * ('b,'e) ty_pvar -> ('t -> 'b, 'e) ty_pvar
+  | Parg : 't * ('a,'e) ty * ('b,'e) ty_pvar -> ('t * 'a -> 'b, 'e) ty_pvar
 *)
 (*
    An attempt at encoding omega examples from the 2nd Central European
    Functional Programming School:
-   Generic Programming in Omega, by Tim Sheard and Nathan Linger
-   http://web.cecs.pdx.edu/~sheard/
+     Generic Programming in Omega, by Tim Sheard and Nathan Linger
+          http://web.cecs.pdx.edu/~sheard/
 *)
 
 (* Basic types *)
@@ -3305,7 +3305,7 @@ Error: Types marked with the immediate attribute must be
 
    New: implicit pack is also supported, and you only need to be able
    to infer the the module type path from the context.
-*)
+ *)
 (* ocaml -principal *)
 
 (* Use a module pattern *)
@@ -5227,21 +5227,21 @@ module type S' = S with module M := String
 
 (* with module type *)
 (*
-   module type S = sig module type T module F(X:T) : T end;;
-   module type T0 = sig type t end;;
-   module type S1 = S with module type T = T0;;
-   module type S2 = S with module type T := T0;;
-   module type S3 = S with module type T := sig type t = int end;;
-   module H = struct
-   include (Hashtbl : module type of Hashtbl with
-   type statistics := Hashtbl.statistics
-   and module type S := Hashtbl.S
-   and module Make := Hashtbl.Make
-   and module MakeSeeded := Hashtbl.MakeSeeded
-   and module type SeededS := Hashtbl.SeededS
-   and module type HashedType := Hashtbl.HashedType
-   and module type SeededHashedType := Hashtbl.SeededHashedType)
-   end;;
+module type S = sig module type T module F(X:T) : T end;;
+module type T0 = sig type t end;;
+module type S1 = S with module type T = T0;;
+module type S2 = S with module type T := T0;;
+module type S3 = S with module type T := sig type t = int end;;
+module H = struct
+  include (Hashtbl : module type of Hashtbl with
+           type statistics := Hashtbl.statistics
+           and module type S := Hashtbl.S
+           and module Make := Hashtbl.Make
+           and module MakeSeeded := Hashtbl.MakeSeeded
+           and module type SeededS := Hashtbl.SeededS
+           and module type HashedType := Hashtbl.HashedType
+           and module type SeededHashedType := Hashtbl.SeededHashedType)
+end;;
 *)
 
 (* A subtle problem appearing with -principal *)
@@ -6066,14 +6066,14 @@ class ['entity] entity_container =
 let f (x : entity entity_container) = ()
 
 (*
-   class world =
-   object
-   val entity_container : entity entity_container = new entity_container
+class world =
+  object
+    val entity_container : entity entity_container = new entity_container
 
-   method add_entity (s : entity) =
-   entity_container#add_entity (s :> entity)
+    method add_entity (s : entity) =
+      entity_container#add_entity (s :> entity)
 
-   end
+  end
 *)
 (* Two v's in the same class *)
 class c v =
@@ -10089,9 +10089,10 @@ let _ =
 (*$*)
 
 (*$
-  [%string {| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  zzzzzzzzzzzzzzzzzzzzzzzzzzzz
-      |}]
+    [%string
+      {| xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+zzzzzzzzzzzzzzzzzzzzzzzzzzzz
+    |}]
 *)
 (*$*)
 

--- a/test/passing/tests/source.ml.err
+++ b/test/passing/tests/source.ml.err
@@ -1,2 +1,2 @@
 Warning: tests/source.ml:702 exceeds the margin
-Warning: tests/source.ml:2318 exceeds the margin
+Warning: tests/source.ml:2325 exceeds the margin

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -1471,15 +1471,22 @@ let ty_list : type a e. (a, e) ty -> (a vlist, e) ty =
             function Thd, Noarg -> `Nil | Ttl Thd, v -> `Cons v
        end ) )
 
-(* type (_,_) ty_assoc = | Anil : (unit,'e) ty_assoc | Acons : string *
-   ('a,'e) ty * ('b,'e) ty_assoc -> ('a -> 'b, 'e) ty_assoc
+(*
+type (_,_) ty_assoc =
+  | Anil : (unit,'e) ty_assoc
+  | Acons : string * ('a,'e) ty * ('b,'e) ty_assoc -> ('a -> 'b, 'e) ty_assoc
 
-   and (_,_) ty_pvar = | Pnil : ('a,'e) ty_pvar | Pconst : 't * ('b,'e)
-   ty_pvar -> ('t -> 'b, 'e) ty_pvar | Parg : 't * ('a,'e) ty * ('b,'e)
-   ty_pvar -> ('t * 'a -> 'b, 'e) ty_pvar *)
-(* An attempt at encoding omega examples from the 2nd Central European
-   Functional Programming School: Generic Programming in Omega, by Tim Sheard
-   and Nathan Linger http://web.cecs.pdx.edu/~sheard/ *)
+and (_,_) ty_pvar =
+  | Pnil : ('a,'e) ty_pvar
+  | Pconst : 't * ('b,'e) ty_pvar -> ('t -> 'b, 'e) ty_pvar
+  | Parg : 't * ('a,'e) ty * ('b,'e) ty_pvar -> ('t * 'a -> 'b, 'e) ty_pvar
+*)
+(*
+   An attempt at encoding omega examples from the 2nd Central European
+   Functional Programming School:
+     Generic Programming in Omega, by Tim Sheard and Nathan Linger
+          http://web.cecs.pdx.edu/~sheard/
+*)
 
 (* Basic types *)
 
@@ -1501,8 +1508,8 @@ let l1 = Scons (3, Scons (5, Snil))
 
 (* We do not have type level functions, so we need to use witnesses. *)
 (* We copy here the definitions from section 3.9 *)
-(* Note the addition of the ['a nat] argument to PlusZ, since we do not have
-   kinds *)
+(* Note the addition of the ['a nat] argument to PlusZ, since we do not
+   have kinds *)
 type (_, _, _) plus =
   | PlusZ : 'a nat -> (zero, 'a, 'a) plus
   | PlusS : ('a, 'b, 'c) plus -> ('a succ, 'b, 'c succ) plus
@@ -3156,14 +3163,16 @@ Error: Types marked with the immediate attribute must be
        non-pointer types like int or bool
 |}]
 
-(* Implicit unpack allows to omit the signature in (val ...) expressions.
+(*
+   Implicit unpack allows to omit the signature in (val ...) expressions.
 
-   It also adds (module M : S) and (module M) patterns, relying on implicit
-   (val ...) for the implementation. Such patterns can only be used in
-   function definition, match clauses, and let ... in.
+   It also adds (module M : S) and (module M) patterns, relying on
+   implicit (val ...) for the implementation. Such patterns can only
+   be used in function definition, match clauses, and let ... in.
 
-   New: implicit pack is also supported, and you only need to be able to
-   infer the the module type path from the context. *)
+   New: implicit pack is also supported, and you only need to be able
+   to infer the the module type path from the context.
+ *)
 (* ocaml -principal *)
 
 (* Use a module pattern *)
@@ -4994,15 +5003,23 @@ end
 module type S' = S with module M := String
 
 (* with module type *)
-(* module type S = sig module type T module F(X:T) : T end;; module type T0 =
-   sig type t end;; module type S1 = S with module type T = T0;; module type
-   S2 = S with module type T := T0;; module type S3 = S with module type T :=
-   sig type t = int end;; module H = struct include (Hashtbl : module type of
-   Hashtbl with type statistics := Hashtbl.statistics and module type S :=
-   Hashtbl.S and module Make := Hashtbl.Make and module MakeSeeded :=
-   Hashtbl.MakeSeeded and module type SeededS := Hashtbl.SeededS and module
-   type HashedType := Hashtbl.HashedType and module type SeededHashedType :=
-   Hashtbl.SeededHashedType) end;; *)
+(*
+module type S = sig module type T module F(X:T) : T end;;
+module type T0 = sig type t end;;
+module type S1 = S with module type T = T0;;
+module type S2 = S with module type T := T0;;
+module type S3 = S with module type T := sig type t = int end;;
+module H = struct
+  include (Hashtbl : module type of Hashtbl with
+           type statistics := Hashtbl.statistics
+           and module type S := Hashtbl.S
+           and module Make := Hashtbl.Make
+           and module MakeSeeded := Hashtbl.MakeSeeded
+           and module type SeededS := Hashtbl.SeededS
+           and module type HashedType := Hashtbl.HashedType
+           and module type SeededHashedType := Hashtbl.SeededHashedType)
+end;;
+*)
 
 (* A subtle problem appearing with -principal *)
 type -'a t
@@ -5835,13 +5852,16 @@ class ['entity] entity_container =
 
 let f (x : entity entity_container) = ()
 
-(* class world = object val entity_container : entity entity_container = new
-   entity_container
+(*
+class world =
+  object
+    val entity_container : entity entity_container = new entity_container
 
-   method add_entity (s : entity) = entity_container#add_entity (s :>
-   entity)
+    method add_entity (s : entity) =
+      entity_container#add_entity (s :> entity)
 
-   end *)
+  end
+*)
 (* Two v's in the same class *)
 class c v =
   object


### PR DESCRIPTION
I added a test about the weird test_branch diff you observed: test/passing/tests/asterisk_prefixed_cmts.ml

Not checking the margin in `Cmts.break_comment_group` preserves the formatting.